### PR TITLE
Fixed img:fill_polygon checking wrong argument for color

### DIFF
--- a/limlib2.c
+++ b/limlib2.c
@@ -1020,7 +1020,7 @@ static int imagem_fill_polygon(lua_State *L) {
   Image im = check_Image(L, 1);
   Polygon po = check_Polygon(L, 2);
   if (lua_gettop(L)>=3) { /* given a colour */
-    Imlib_Color *c = (Imlib_Color*)luaL_checkudata(L, 4, "imlib2.color");
+    Imlib_Color *c = (Imlib_Color*)luaL_checkudata(L, 3, "imlib2.color");
     set_color(c);
   }
   imlib_context_set_image(im);


### PR DESCRIPTION
There's a small issue with img:fill_poly where it checks color thinking it should be the fourth argument, but it really should be checking the third.

This causes something like this

```
img:fill_polygon(poly, color)
```

To error with `bad argument #3 to 'fill_polygon' (imlib2.color expected, got no value)`

To work around this issue you need to to

```
img:fill_polygon(poly, nil, color)
```

But I figured it would be best to make a pull request.
